### PR TITLE
Validate booking list parameters

### DIFF
--- a/app/api/users/me/bookings/route.ts
+++ b/app/api/users/me/bookings/route.ts
@@ -2,14 +2,19 @@ export const runtime = 'nodejs';
 
 import { bookings } from '@/lib/bookings';
 import { requireUser } from '@/lib/auth';
+import { ListBookingsSchema } from '@/lib/schemas';
 
 export async function GET(req: Request) {
   try {
     const userId = await requireUser(req);
     const url = new URL(req.url);
-    const status = url.searchParams.get('status') ?? undefined;
-    const cursor = url.searchParams.get('cursor') ?? undefined;
-    const data = await bookings.list(userId, status || undefined, cursor || undefined);
+    const params = Object.fromEntries(url.searchParams);
+    const parsed = ListBookingsSchema.safeParse(params);
+    if (!parsed.success) {
+      return new Response(JSON.stringify({ code: 'INVALID_REQUEST', issues: parsed.error.issues }), { status: 400 });
+    }
+    const { status, cursor } = parsed.data;
+    const data = await bookings.list(userId, status, cursor);
     return Response.json(data);
   } catch (err: any) {
     return new Response(JSON.stringify({ code: 'LIST_FAILED', message: err?.message || 'Error' }), { status: 400 });

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+
+export const ListBookingsSchema = z.object({
+  status: z.enum(['RESERVED', 'CONFIRMED', 'CANCELLED']).optional(),
+  cursor: z.string().optional(),
+});


### PR DESCRIPTION
## Summary
- add shared `ListBookingsSchema` for bookings listing
- validate query parameters in bookings and user bookings routes
- return 400 with structured error on invalid requests

## Testing
- `pnpm lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a74814fcb88328853648aa67ae091d