### PR TITLE
Define Contact and Passenger types for bookings

### DIFF
--- a/app/api/bookings/[id]/route.ts
+++ b/app/api/bookings/[id]/route.ts
@@ -3,6 +3,7 @@ export const runtime = 'nodejs';
 import { z } from 'zod';
 import { bookings } from '@/lib/bookings';
 import { requireUser } from '@/lib/auth';
+import { ContactSchema, PassengerSchema } from '@/lib/flights/types';
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   try {
@@ -15,8 +16,8 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
 }
 
 const PatchSchema = z.object({
-  contact: z.any().optional(),
-  passengers: z.array(z.any()).optional(),
+  contact: ContactSchema.optional(),
+  passengers: z.array(PassengerSchema).optional(),
 });
 
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {
@@ -24,7 +25,7 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     const userId = await requireUser(req);
     const body = await req.json();
     const patch = PatchSchema.parse(body);
-    const updated = await bookings.update(userId, params.id, patch as any);
+    const updated = await bookings.update(userId, params.id, patch);
     return Response.json(updated);
   } catch (err: any) {
     return new Response(JSON.stringify({ code: 'UPDATE_FAILED', message: err?.message || 'Error' }), { status: 400 });

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -4,11 +4,12 @@ import { z } from 'zod';
 import { bookings } from '@/lib/bookings';
 import { requireUser } from '@/lib/auth';
 import { withIdempotency } from '@/lib/idempotency';
+import { ContactSchema, PassengerSchema } from '@/lib/flights/types';
 
 const Schema = z.object({
   offerId: z.string(),
-  contact: z.any(),
-  passengers: z.array(z.any()),
+  contact: ContactSchema,
+  passengers: z.array(PassengerSchema),
 });
 
 export async function POST(req: Request) {
@@ -17,7 +18,7 @@ export async function POST(req: Request) {
     const args = Schema.parse(await req.json());
     const idem = req.headers.get('Idempotency-Key') || '';
     const { result } = await withIdempotency(userId, 'POST', '/api/bookings', idem, () =>
-      bookings.create(userId, args as any)
+      bookings.create(userId, args)
     );
     return new Response(
       JSON.stringify({ bookingId: result.id, status: result.status, providerRef: result.providerRef }),

--- a/lib/bookings.ts
+++ b/lib/bookings.ts
@@ -1,10 +1,12 @@
 import { db } from './prisma';
 import { provider } from './flights';
+import type { Contact, Passenger } from './flights/types';
+import { Prisma } from '@prisma/client';
 
 type CreateArgs = {
   offerId: string;
-  contact: any;
-  passengers: any[];
+  contact: Contact;
+  passengers: Passenger[];
 };
 
 export const bookings = {
@@ -31,8 +33,8 @@ export const bookings = {
           totalAmount: offer.price.amount,
           currency: offer.price.currency,
           offerId: offer.id,
-          passengers: args.passengers as any,
-          contact: args.contact as any,
+          passengers: args.passengers as Prisma.JsonArray,
+          contact: args.contact as Prisma.JsonObject,
         },
       });
       await tx.segment.create({
@@ -63,15 +65,15 @@ export const bookings = {
     return booking;
   },
 
-  async update(userId: string, bookingId: string, patch: { contact?: any; passengers?: any[] }) {
+  async update(userId: string, bookingId: string, patch: { contact?: Contact; passengers?: Passenger[] }) {
     const booking = await db.booking.findFirst({ where: { id: bookingId, userId } });
     if (!booking) throw new Error('Booking not found');
     if (booking.status === 'CANCELLED') throw new Error('Cannot update a cancelled booking');
     return db.booking.update({
       where: { id: booking.id },
       data: {
-        contact: typeof patch.contact !== 'undefined' ? (patch.contact as any) : undefined,
-        passengers: typeof patch.passengers !== 'undefined' ? (patch.passengers as any) : undefined,
+        contact: typeof patch.contact !== 'undefined' ? (patch.contact as Prisma.JsonObject) : undefined,
+        passengers: typeof patch.passengers !== 'undefined' ? (patch.passengers as Prisma.JsonArray) : undefined,
       },
       include: { segments: true },
     });

--- a/lib/flights/provider.ts
+++ b/lib/flights/provider.ts
@@ -1,3 +1,5 @@
+import type { Contact, Passenger } from './types';
+
 export interface SearchParams {
   origin: string;
   destination: string;
@@ -20,8 +22,8 @@ export interface ProviderOffer {
 
 export interface BookingInput {
   offerId: string;
-  contact: any;
-  passengers: any[];
+  contact: Contact;
+  passengers: Passenger[];
 }
 
 export interface BookingResult {

--- a/lib/flights/types.ts
+++ b/lib/flights/types.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+/**
+ * Contact details for the booking holder.
+ */
+export interface Contact {
+  email: string;
+  phone?: string;
+}
+
+export const ContactSchema: z.ZodType<Contact> = z.object({
+  email: z.string().email(),
+  phone: z.string().optional(),
+});
+
+/**
+ * Passenger information for each traveler in a booking.
+ */
+export interface Passenger {
+  type: 'ADULT' | 'CHILD' | 'INFANT';
+  firstName: string;
+  lastName: string;
+}
+
+export const PassengerSchema: z.ZodType<Passenger> = z.object({
+  type: z.enum(['ADULT', 'CHILD', 'INFANT']),
+  firstName: z.string(),
+  lastName: z.string(),
+});
+


### PR DESCRIPTION
## Summary
- add Contact and Passenger interfaces with matching Zod schemas
- use strong types in flights provider, bookings logic, and booking APIs
- remove `any` usages and `as any` casts when persisting booking data

## Testing
- `pnpm lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a74811ebf08328893c021e6d181756