### PR TITLE
refactor: use RequestCookies for auth

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,19 +1,11 @@
 // Minimal auth stub for prototype
 // Replace with NextAuth getServerSession later.
 
-function parseCookie(header: string | null): Record<string, string> {
-  const out: Record<string, string> = {};
-  if (!header) return out;
-  for (const part of header.split(';')) {
-    const [k, v] = part.split('=');
-    if (k && v) out[k.trim()] = decodeURIComponent(v);
-  }
-  return out;
-}
+import { RequestCookies } from 'next/dist/server/web/spec-extension/cookies';
 
 export async function requireUser(req: Request): Promise<string> {
-  const cookies = parseCookie(req.headers.get('cookie'));
-  const cookieId = cookies['uid'];
+  const cookieStore = new RequestCookies(req.headers);
+  const cookieId = cookieStore.get('uid')?.value;
   const headerId = req.headers.get('x-user-id');
   const id = cookieId || headerId;
   if (!id) throw new Response('Unauthorized', { status: 401 });


### PR DESCRIPTION
## Summary
- use Next.js `RequestCookies` to parse cookies
- avoid incorrect uid splitting and simplify `requireUser`

## Testing
- `pnpm lint` *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a7481c47bc83288405cf602ce2d610